### PR TITLE
feat(back): CORS configurable, health con estado de DB y conexión rob…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -70,8 +70,6 @@ const corsOptions = {
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With']
 };
 app.use(cors(corsOptions));
-// Preflight para todos los endpoints
-app.options('*', cors(corsOptions));
 app.use(morgan(isProd ? 'tiny' : 'dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
…usta a Atlas

- CORS por ALLOWED_ORIGINS con soporte wildcard (*.vercel.app) y bandera CORS_ALLOW_ALL para permitir cualquier origen.
- Swagger activable por SWAGGER_ENABLED y oculto por defecto en producción.
- Healthcheck /health ahora incluye estado de conexión de Mongoose.
- Conexión a Mongo: timeout de selección 30s, TLS por defecto; servidor arranca solo tras conectar.
- Seeds: scripts start:seed/dev:seed y SEED_ON_START para dev; alias npm run seeds.
- Ejemplos de env actualizados (ALLOWED_ORIGINS, SWAGGER_ENABLED, CORS_ALLOW_ALL).